### PR TITLE
chore(deps): bump flutter_secure_storage to ^10.0.0

### DIFF
--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,11 +6,11 @@ import FlutterMacOS
 import Foundation
 
 import app_links
-import flutter_secure_storage_macos
+import flutter_secure_storage_darwin
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
-  FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
+  FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -120,6 +120,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  ffi_leak_tracker:
+    dependency: transitive
+    description:
+      name: ffi_leak_tracker
+      sha256: "4093d4ef9ca06ffe2786e73bfb25e22aa92112b9bb4ec941f11e3e6b61489a97"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2"
   file:
     dependency: transitive
     description:
@@ -145,50 +153,50 @@ packages:
     dependency: transitive
     description:
       name: flutter_secure_storage
-      sha256: "9cad52d75ebc511adfae3d447d5d13da15a55a92c9410e50f67335b6d21d16ea"
+      sha256: "6848263f9744072d0977347c383fb8b57d9780319a6bf5238b5a2866a029de62"
       url: "https://pub.dev"
     source: hosted
-    version: "9.2.4"
+    version: "10.2.0"
+  flutter_secure_storage_darwin:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_darwin
+      sha256: "67cd1ff671add31dc13e45194398187a04bb63804b37fa47866afae296d73fcb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   flutter_secure_storage_linux:
     dependency: transitive
     description:
       name: flutter_secure_storage_linux
-      sha256: be76c1d24a97d0b98f8b54bce6b481a380a6590df992d0098f868ad54dc8f688
+      sha256: "2b5c76dce569ab752d55a1cee6a2242bcc11fdba927078fb88c503f150767cda"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.3"
-  flutter_secure_storage_macos:
-    dependency: transitive
-    description:
-      name: flutter_secure_storage_macos
-      sha256: "6c0a2795a2d1de26ae202a0d78527d163f4acbb11cde4c75c670f3a0fc064247"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.3"
+    version: "3.0.0"
   flutter_secure_storage_platform_interface:
     dependency: transitive
     description:
       name: flutter_secure_storage_platform_interface
-      sha256: cf91ad32ce5adef6fba4d736a542baca9daf3beac4db2d04be350b87f69ac4a8
+      sha256: "8ceea1223bee3c6ac1a22dabd8feefc550e4729b3675de4b5900f55afcb435d6"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "2.0.1"
   flutter_secure_storage_web:
     dependency: transitive
     description:
       name: flutter_secure_storage_web
-      sha256: f4ebff989b4f07b2656fb16b47852c0aab9fed9b4ec1c70103368337bc1886a9
+      sha256: "073a62b3aeb866ab4ce795f960413948e51e5a42a9b0c8333b6daf5bb3208a1c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "2.1.1"
   flutter_secure_storage_windows:
     dependency: transitive
     description:
       name: flutter_secure_storage_windows
-      sha256: b20b07cb5ed4ed74fc567b78a72936203f587eba460af1df11281c9326cd3709
+      sha256: "8f42f359f187a94dce7a3ab2ec5903d013dddfc7127078ebab19fa244c3840e8"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "4.2.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -239,14 +247,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.7"
   leak_tracker:
     dependency: transitive
     description:
@@ -576,10 +576,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
+      sha256: a1fc9eb9248baa05dfc12ed5b66e377b3e23f095eec078e0371622b9033810d9
       url: "https://pub.dev"
     source: hosted
-    version: "5.15.0"
+    version: "6.2.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/lib/src/service/local-storage-service/flutter_secure_impl.dart
+++ b/lib/src/service/local-storage-service/flutter_secure_impl.dart
@@ -3,40 +3,19 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'better_auth_local_storage_service.dart';
 
 class FlutterSecureImpl extends BetterAuthLocalStorage {
-  final FlutterSecureStorage _storage = FlutterSecureStorage();
-  @override
-  Future<void> create(String key, String value) async {
-    try {
-      await _storage.write(key: key, value: value);
-    } catch (e) {
-      rethrow;
-    }
-  }
+  final FlutterSecureStorage _storage = const FlutterSecureStorage();
 
   @override
-  Future<void> delete(String key) async {
-    try {
-      await _storage.delete(key: key);
-    } catch (e) {
-      rethrow;
-    }
-  }
+  Future<void> create(String key, String value) =>
+      _storage.write(key: key, value: value);
 
   @override
-  Future<String> get(String key) async {
-    try {
-      return await _storage.read(key: key) ?? '';
-    } catch (e) {
-      rethrow;
-    }
-  }
+  Future<void> delete(String key) => _storage.delete(key: key);
 
   @override
-  Future<void> update(String key, String value) async {
-    try {
-      await _storage.write(key: key, value: value);
-    } catch (e) {
-      rethrow;
-    }
-  }
+  Future<String> get(String key) async => await _storage.read(key: key) ?? '';
+
+  @override
+  Future<void> update(String key, String value) =>
+      _storage.write(key: key, value: value);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,13 +5,13 @@ homepage: "https://github.com/yourusername/better_auth_client"
 
 environment:
   sdk: ^3.7.2
-  flutter: ">=1.17.0"
+  flutter: ">=3.19.0"
 
 dependencies:
   flutter:
     sdk: flutter
   http: ^1.2.1
-  flutter_secure_storage: ^9.0.0
+  flutter_secure_storage: ^10.0.0
   url_launcher: ^6.2.5
   app_links: ^7.0.0
 


### PR DESCRIPTION
## Summary
Bumps `flutter_secure_storage` to v10 and raises the minimum Flutter SDK constraint accordingly.

## Changes
- Update `flutter_secure_storage` dependency from `^9.0.0` to `^10.0.0`
- Raise `environment.flutter` from `>=1.17.0` to `>=3.19.0` (required by v10)
- Clean up `FlutterSecureImpl`: remove redundant try/catch blocks, use const constructor, and simplify method bodies

## Verification
- `flutter pub get` resolves v10.2.0 correctly
- All existing tests pass
- No new analysis issues introduced

> Written by Kimi 2.6